### PR TITLE
upd 

### DIFF
--- a/app/src/main/java/ru/wintrade/mvp/presenter/subscriber/SubscriberPostPresenter.kt
+++ b/app/src/main/java/ru/wintrade/mvp/presenter/subscriber/SubscriberPostPresenter.kt
@@ -127,7 +127,7 @@ class SubscriberPostPresenter : MvpPresenter<SubscriberNewsView>() {
             isLoading = true
 
             apiRepo
-                .getPublisherPosts(profile.token!!, nextPage!!)
+                .getPostsFollowerAndObserving(profile.token!!, nextPage!!)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ pag ->
                     if (pag.results.isEmpty()) {


### PR DESCRIPTION
У Subscriber теперь тоже в ленте отображаются посты за кем он просто наблюдает
https://trello.com/c/6goyIP1d/285-1119-при-добавлении-в-лист-наблюдения-трейдера-подписчик-в-своем-профиле-подписчика-в-новостной-ленте-видит-посты-этого-трейдера